### PR TITLE
Change background color to red for both light and dark modes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: red;
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -39,7 +39,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: red;
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary

This PR changes the background color to red for both light and dark modes, as requested.

## Changes
- Updated the `--background` CSS variable in `src/index.css` for both `:root` (light mode) and `.dark` (dark mode) to `red`.

## Prompt Section
**Prompt:**
> Please change the background color to red in the DCA-Simulator repository.

---

Please review and let me know if further adjustments are needed.