### PR TITLE
Change background color to red for both light and dark themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: red;
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -39,7 +39,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: red;
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary

This PR changes the background color to red for both the light and dark themes by updating the `--background` CSS variable in `src/index.css`.

## Changes
- Set `--background: red;` in the `:root` selector (light theme)
- Set `--background: red;` in the `.dark` selector (dark theme)

## Motivation
This change was made in response to the following prompt:

> Change the background color to red in the code repository.

---

Please review and let me know if further adjustments are needed.