### PR TITLE
Change background color to red for both light and dark themes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: red;
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -39,7 +39,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: red;
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
## Summary
Changed the background color to red for both light and dark themes by updating the `--background` CSS variable in `src/index.css`.

## Details
- Modified the `:root` and `.dark` CSS variables for `--background` to use `red` instead of the previous color value.

## Prompt Section
**Prompt:** Change the background color to red in the repository mfanselmo/DCA-Simulator on the main branch.

No other changes were made.
